### PR TITLE
`_` is hidden by diff line

### DIFF
--- a/src/main/webapp/assets/vendors/jsdifflib/diffview.css
+++ b/src/main/webapp/assets/vendors/jsdifflib/diffview.css
@@ -66,7 +66,7 @@ table.diff thead th.texttitle {
 }
 table.diff tbody td {
 	padding:0px .4em;
-	padding-top:.4em;
+	padding-top:.2em;
 	vertical-align:top;
 	border-top: none;
 }


### PR DESCRIPTION
Fix height of diff line 

before diff area
![before](https://cloud.githubusercontent.com/assets/97468/7647999/5bb360d2-fb18-11e4-929b-d9148eadaad2.png)

after diff area
![after](https://cloud.githubusercontent.com/assets/97468/7648002/67e77d5c-fb18-11e4-8095-b25919d80707.png)
